### PR TITLE
Contribution guidelines & related docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at aserra@werfen.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers (see [Anatomy of an open source project](https://opensource.guide/how-to-contribute/#anatomy-of-an-open-source-project) for a description of these roles) pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ The following resources may help you with the conventions we are used as well as
 
 ### Roadmap
 
-Next steps of the task force are defined and updated on the [roadmap](https://github.com/systelab/systelab-components/projects) for the current year.
+Next steps of the task force are defined and updated on the [roadmap](https://github.com/systelab/systelab-cpp-doc/projects) for the current year.
 
 
 ## How Can I Contribute?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to CSW C++ Task Force
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to CSW C++ task force and its libraries. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+
+#### Table Of Contents
+
+[Code of Conduct](#code-of-conduct)
+
+[I don't want to read this whole thing, I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
+
+[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+  * [Catalog of libraries](#catalog-of-libraries)
+  * [Toolchain] (#toolchain)
+  * [Conventions and decisions](#conventions-and-decisions)
+  * [Roadmap](#roadmap)
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Pull Requests](#pull-requests)
+
+[Additional Notes](#additional-notes)
+  * [Issue and Pull Request Labels](#issue-and-pull-request-labels)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## I don't want to read this whole thing I just have a question!!!
+
+> **Note:** Please don't file an issue to ask a question. You'll get faster results by using the resources below.
+
+We have an official channel on Microsoft Teams and where the community chimes in with helpful advice if you have questions.
+
+
+## What should I know before I get started?
+
+### Catalog of libraries
+
+C++ task force is a large open source project and it's made up of multiple repositories. When you initially consider contributing, you might be unsure about which repository should go the functionality you want to change or report a bug for. The [catalog of libraries](CATALOG.md) should help you with that.
+
+### Toolchain
+
+Check our [toolchain](TOOLCHAIN.md) document for a complete list of the set of tools we work with.
+
+### Conventions and decisions
+
+The following resources may help you with the conventions we are used as well as the decisions taken:
+* [Coding guidelines] (CODING_GUIDELINES.md)
+* [Design decisions](DESIGN_DECISIONS.md)
+
+### Roadmap
+
+Next steps of the task force are defined and updated on the [roadmap](https://github.com/systelab/systelab-components/projects) for the current year.
+
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for a C++ library. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+
+Before creating bug reports, please check the list of open bugs of the library repository as you might find out that you don't need to create one. 
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/) or [Bitbucket issues](https://bitbucket.org/). After you've determined [which repository](#catalog-of-libraries) your bug is related to, create an issue on that repository and provide the following information by filling in the template.
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you use the library, e.g. which API method you used, or how you configured it. When listing steps, **don't just say what you did, but explain how you did it**. 
+* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **If you're reporting a crash**, include a crash report with a stack trace from the operating system. 
+* **If the problem is related to performance or memory**, include a CPU profile capture with your report.
+* **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Atom, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+
+Before creating enhancement suggestions, please check the list of issues of the library repository as you might find out that you don't need to create one. 
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](#catalog-of-libraries) your enhancement suggestion is related to, create an issue on that repository and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+
+### Pull Requests
+
+The process described here has several goals:
+
+- Maintain quality of libraries
+- Fix problems that are important to users
+- Engage the community in working toward the best possible library
+- Enable a sustainable system for libraries' maintainers to review contributions
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. This task force is aligned with the feature-branch strategy. The branch naming convention is "bugfix- or feature-" plus the issue number in Github or Bitbucket.
+ > For example: bugfix-200
+
+2. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
+
+3. The changes can be tested in your local before publishing. Make sure all automated tests pass.
+
+4. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
+
+5. While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+
+6. Before merging the pull request, the master branch needs to be merged into current.
+
+7. Once it's merged, the author must transition it to the status "Ready to test" in the [project](https://github.com/systelab/systelab-components/projects)
+
+8. Based upon need, the library will be published into the npm repository. This process must be done by an authorized user.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ The following is a set of guidelines for contributing to CSW C++ task force and 
 
 [What should I know before I get started?](#what-should-i-know-before-i-get-started)
   * [Catalog of libraries](#catalog-of-libraries)
-  * [Toolchain] (#toolchain)
+  * [Toolchain](#toolchain)
   * [Conventions and decisions](#conventions-and-decisions)
   * [Roadmap](#roadmap)
 
@@ -22,8 +22,6 @@ The following is a set of guidelines for contributing to CSW C++ task force and 
   * [Suggesting Enhancements](#suggesting-enhancements)
   * [Pull Requests](#pull-requests)
 
-[Additional Notes](#additional-notes)
-  * [Issue and Pull Request Labels](#issue-and-pull-request-labels)
 
 ## Code of Conduct
 
@@ -113,7 +111,7 @@ Please follow these steps to have your contribution considered by the maintainer
 
 2. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
 
-3. The changes can be tested in your local before publishing. Make sure all automated tests pass.
+3. The changes can be tested in your local before publishing. Make sure all automated tests pass before that.
 
 4. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Explain the problem and include additional details to help maintainers reproduce
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for Atom, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
 Before creating enhancement suggestions, please check the list of issues of the library repository as you might find out that you don't need to create one. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Check our [toolchain](TOOLCHAIN.md) document for a complete list of the set of t
 ### Conventions and decisions
 
 The following resources may help you with the conventions we are used as well as the decisions taken:
-* [Coding guidelines] (CODING_GUIDELINES.md)
+* [Coding guidelines](CODING_GUIDELINES.md)
 * [Design decisions](DESIGN_DECISIONS.md)
 
 ### Roadmap

--- a/DESIGN_DECISIONS.md
+++ b/DESIGN_DECISIONS.md
@@ -1,0 +1,5 @@
+# Design Decisions
+
+When we make a significant decision in how we maintain the project and what we can or cannot support, we will write it on this document. If you have a question around how we do things, check to see if it is already documented here. If it is *not* documented yet, please open a new issue on this repository (https://discuss.atom.io) and ask your question.
+
+

--- a/DESIGN_DECISIONS.md
+++ b/DESIGN_DECISIONS.md
@@ -1,5 +1,5 @@
 # Design Decisions
 
-When we make a significant decision in how we maintain the project and what we can or cannot support, we will write it on this document. If you have a question around how we do things, check to see if it is already documented here. If it is *not* documented yet, please open a new issue on this repository (https://discuss.atom.io) and ask your question.
+When we make a significant decision in how we maintain the project and what we can or cannot support, we will write it on this document. If you have a question around how we do things, check to see if it is already documented here. If it is *not* documented yet, please open a new issue on this repository and ask your question.
 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+# PR Details
+
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail. Do not repeat the Issue description. -->
+
+## Related Issue
+
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Docs change / refactoring / dependency upgrade
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have read the **CONTRIBUTING** document
+- [ ] My code follows the code style of this project
+- [ ] My change requires a change to the documentation 
+- [ ] I have updated the library documentation accordingly (README.md for each repository)
+- [ ] I have recorded this change on the library release notes
+- [ ] I have added tests to cover my changes
+- [ ] All new and existing tests passed
+- [ ] A new branch needs to be created from master to evolve previous versions

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# systelab-cpp-doc
+# C++ Task Force
+
+This is an umbrella repository for C++ development at CSW.
+
+* [How to contribute to C++ task force?](CONTRIBUTING.md)
+* [Catalog of shared libraries](CATALOG.md)
+* [Coding guidelines](CODING_GUIDELINES.md)
+* [Roadmap](https://github.com/systelab/systelab-cpp-doc/projects)

--- a/TOOLCHAIN.md
+++ b/TOOLCHAIN.md
@@ -8,7 +8,7 @@ This document describes the collection of tools used for the different activitie
 Make use of the "CSW-TF C++" team on Microsoft Teams to announce or discuss anything related with the C++ task force. 
 
 
-## Source control management (SCM)
+## Source Control Management
 
 C++ task force works with 2 types of [git](https://git-scm.com/) platforms:
 * *GitHub*: For open source repositories (i.e foundation, adapters, ...)
@@ -19,47 +19,53 @@ Both cloud platforms integrate issue trackers on each repository that will be us
 
 ## Continuous integration
 
-There are different CI tools involved on the platform used on each repository:
+There are different tools involved on the continuous integration used on each repository:
 * [Travis CI](https://travis-ci.org/github/systelab): Used for Linux & MacOS configurations (only open source)
 * [AppVeyor](https://ci.appveyor.com/): Used for Windows configurations (only open source)
 * [GitHub Actions](https://github.com/features/actions): Used to generate automated documentation (only open source)
 * [Jenkins](https://www.jenkins.io/): Used for complete CI of private repositories
+
+> Pending to evaluate if it's worth to move all CI to GitHub Actions, thus the toolchain will be simplified.
 
 
 ## Cross platform
 
 Whenever possible, repositories are configured to be cross-platform by making use of [cmake](https://cmake.org/).
 
-See [configurations matrix](CONFIGURATIONS_MATRIX.md) for details about the environment used on each project.
+See [configurations matrix](CONFIGURATIONS_MATRIX.md) for details about the different environments used on CSW projects.
 
 
-## Package manager
+## Package manager & artifacts
 
-Conan is the package manager to be used under the scope of this task force. It can be used with the following purposes:
+[Conan](https://conan.io/) is "de facto" standard package manager for C++. It should be used in task force libraries to:
+* Manage and retrieve dependencies
+* Pack binaries and deploy them to an artifacts repository
 
-* Dependency management: dependencies 
-
-* Deploy
-
-
- Every library should be prepared to be deployed as a Conan package
-
-
-
-
-
+Thus, every library should contain a conan recipe and be prepared for deployment as a Conan package. However, the artifacts repository will vary depending on the type of repo. While binaries of private libraries will be uploaded to [CSW Artifactory](https://artifactory.systelab.net/), for open source repositories the binaries should go to [JFrogPlatform](http://systelab.jfrog.io/)
 
 
 ## Automated testing
 
-[GoogleTest](https://google.github.io/googletest/) is the reference test automation framework. Thanks to the mocking feature, it is ideal for test automation. 
+[GoogleTest](https://google.github.io/googletest/) is the reference test automation framework of this task force. Thanks to its mocking feature (GMock), it is ideal for creating unit tests. Nevertheless, it can be used also to build tests that have a wider scope such as component tests or integration tests.
 
- 
+It is not possible to define a general rule for the amount of automated test required, so this will be evaluated for each particular case. However, the philosophy should be about testing as much as possible in an automated manner.
+
+Thanks to [Codecov](https://app.codecov.io/), line code coverage will be measured for GitHub projects. Despite not having an specific target value, reports from this tool can be used on pull requests to detect missing scenarios on the created test suites. Moreover, when a library has a coverage below 80%, it is a smell that probably there are some tests missing.
+
+
+## Code quality
+
+In order to find bugs as soon as possible, code of task force repositories will be statically analyzed on every build. This will be achieved by means of CppCheck. However, different tools will be used to display the output reports of this type of analysis:
+
+* [Codacy](https://app.codacy.com/organizations/gh/systelab/repositories) will be used for open source libraries
+* [SonaQube](https://sonarq.systelab.net/) will be the tool to monitor private repositories
+
+> Still pending to define quality gates for this type of analysis
 
 
 ## Documentation
 
-All repositories should contain a README.md file describing:
+All repositories should contain a `README.md` file describing:
 * Purpose of the repository/library
 * List of features provided
 * How to setup (i.e conan, build from sources, ...)

--- a/TOOLCHAIN.md
+++ b/TOOLCHAIN.md
@@ -1,0 +1,67 @@
+# Toolchain
+
+This document describes the collection of tools used for the different activities related with the lifecycle of libraries governed by the CSW C++ task force.
+
+
+## Communication
+
+Make use of the "CSW-TF C++" team on Microsoft Teams to announce or discuss anything related with the C++ task force. 
+
+
+## Source control management (SCM)
+
+C++ task force works with 2 types of [git](https://git-scm.com/) platforms:
+* *GitHub*: For open source repositories (i.e foundation, adapters, ...)
+* *Bitbucket*: For private repositories (i.e core business code, cybersecurity, ...)
+
+Both cloud platforms integrate issue trackers on each repository that will be used for change & defect management. Similarly, code reviews will be performed by the built-in pull request mechanism.
+
+
+## Continuous integration
+
+There are different CI tools involved on the platform used on each repository:
+* [Travis CI](https://travis-ci.org/github/systelab): Used for Linux & MacOS configurations (only open source)
+* [AppVeyor](https://ci.appveyor.com/): Used for Windows configurations (only open source)
+* [GitHub Actions](https://github.com/features/actions): Used to generate automated documentation (only open source)
+* [Jenkins](https://www.jenkins.io/): Used for complete CI of private repositories
+
+
+## Cross platform
+
+Whenever possible, repositories are configured to be cross-platform by making use of [cmake](https://cmake.org/).
+
+See [configurations matrix](CONFIGURATIONS_MATRIX.md) for details about the environment used on each project.
+
+
+## Package manager
+
+Conan is the package manager to be used under the scope of this task force. It can be used with the following purposes:
+
+* Dependency management: dependencies 
+
+* Deploy
+
+
+ Every library should be prepared to be deployed as a Conan package
+
+
+
+
+
+
+
+## Automated testing
+
+[GoogleTest](https://google.github.io/googletest/) is the reference test automation framework. Thanks to the mocking feature, it is ideal for test automation. 
+
+ 
+
+
+## Documentation
+
+All repositories should contain a README.md file describing:
+* Purpose of the repository/library
+* List of features provided
+* How to setup (i.e conan, build from sources, ...)
+* Usage instructions (i.e code snippets are usually very helpful)
+


### PR DESCRIPTION
Added **initial draft** of documentation on how the C++ task force should operate:
* Contribution guidelines
* Code of conduct
* Toolchain
* Pull request template
* Design decisions (placeholder)
* Documentation index (on README.md)